### PR TITLE
0.6.6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "prettier/prettier": ["error"],
     "no-console": "off",
     "no-undef": "error",
-    "linebreak-style": "off"
+    "linebreak-style": "off",
+    "no-const-assign": "error"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.6
+
+- Assets with format \*.ignore.[ext] are ignored while copying.
+- More tests and coverage
+- Supported beforeSetup plugin (beforeSetup plugins run before setting map contents map and pages array).
+- Removed support for getting prefix from domain in siteMetaData.
+- Bug fixes
+- Now it's more easy to add templating engines
+- Supported use of templating files inside contents (also supports frontmatter).
+
 ## 0.6.5
 
 - Added prefix link support

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,13 @@ module.exports = {
     "src/utils/**/*.js",
     "src/index.js",
     "src/ulka-cli/build.js"
-  ]
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 60,
+      functions: 70,
+      lines: 70,
+      statements: 70
+    }
+  }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
 module.exports = {
-  collectCoverage: true
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "src/utils/**/*.js",
+    "src/index.js",
+    "src/ulka-cli/build.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulka",
-  "version": "0.6.6-rc.5",
+  "version": "0.6.6-rc.6",
   "description": "Ulka - A simpler static site generator written in JavaScript",
   "main": "./src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulka",
-  "version": "0.6.6-rc.6",
+  "version": "0.6.6-rc.7",
   "description": "Ulka - A simpler static site generator written in JavaScript",
   "main": "./src/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulka",
-  "version": "0.6.6-rc.7",
+  "version": "0.6.6",
   "description": "Ulka - A simpler static site generator written in JavaScript",
   "main": "./src/index.js",
   "bin": {

--- a/src/utils/build-utils.js
+++ b/src/utils/build-utils.js
@@ -290,7 +290,7 @@ async function contentToHtml(contentData, contents, info) {
         contentData.html = renderUlka(html, context, filePath, info)
       } else {
         context = createContext(context, filePath, info)
-        contentData.html = extRenderer(contentData.content, context, info)
+        contentData.html = extRenderer(contentData.content, context, filePath)
       }
     } else {
       contentData.html = contentData.content
@@ -333,7 +333,11 @@ async function contentToHtml(contentData, contents, info) {
         contentData.templatePath || filePath,
         info
       )
-      html = info.renderer[ext](contentData.template, context, info)
+      html = info.renderer[ext](
+        contentData.template,
+        context,
+        contentData.templatePath || filePath
+      )
     }
 
     const parsedBuildPath = path.parse(contentData.buildPath)
@@ -388,7 +392,7 @@ async function pageToHtml(pageData, pages, contents, info) {
         pageData.html = renderUlka(pageData.content, context, filePath, info)
       } else {
         context = createContext(context, filePath, info)
-        pageData.html = extRenderer(pageData.content, context, info)
+        pageData.html = extRenderer(pageData.content, context, filePath)
       }
     } else {
       pageData.html = pageData.content

--- a/src/utils/build-utils.js
+++ b/src/utils/build-utils.js
@@ -279,7 +279,7 @@ async function contentToHtml(contentData, contents, info) {
     }
 
     if (contentData.type === "raw") {
-      const context = { ...contentData, info }
+      let context = { ...contentData, info }
       const filePath = contentData.source || info.cwd
 
       const ext = path.parse(filePath).ext
@@ -442,14 +442,14 @@ function createInfo(cwd, task) {
     }
 
     const pagesExtensions = [".ulka"]
-    const contentsExtesnions = [".md"]
+    const contentsExtensions = [".md"]
 
     return {
       configs,
       cwd,
       task,
       pagesExtensions,
-      contentsExtesnions,
+      contentsExtensions,
       ignoreExtensions: [".ulka", ".md"],
       renderer: {},
       prefix

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -223,7 +223,7 @@ function copyAssets(info) {
   for (const file of allFilesinSrc) {
     const parsed = path.parse(file)
 
-    if (!parsed.name.endsWith("ulka") && !ignoreExt.includes(parsed.ext)) {
+    if (!parsed.name.endsWith("ignore") && !ignoreExt.includes(parsed.ext)) {
       try {
         const strToHash = path.relative(info.cwd, file).split(path.sep).join("")
 

--- a/src/utils/ulka-fs.js
+++ b/src/utils/ulka-fs.js
@@ -34,7 +34,7 @@ function mkdir(pathToDirectory) {
  * Find all files is a directory using recursion
  *
  * @param {String} dirPath path to the directory to search files.
- * @param {String} [ext] extension of the files to search.
+ * @param {String|String[]} [ext] extension of the files to search.
  * @param {String[]} [arrayOfFiles]
  * @return {String[]} Array of files
  */
@@ -53,7 +53,14 @@ function allFiles(dirPath, ext, arrayOfFiles = []) {
       if (fs.statSync(pathTo).isDirectory()) {
         arrayOfFiles = allFiles(pathTo, ext, arrayOfFiles)
       } else {
-        if (!ext || file.endsWith(ext)) arrayOfFiles.push(pathTo)
+        const fileExt = path.parse(file).ext
+
+        const shouldPushToFilesArray =
+          !ext ||
+          (typeof ext === "string" && ext === fileExt) ||
+          (Array.isArray(ext) && ext.includes(fileExt))
+
+        if (shouldPushToFilesArray) arrayOfFiles.push(pathTo)
       }
     })
 

--- a/tests/e2e/basic.e2e.test.js
+++ b/tests/e2e/basic.e2e.test.js
@@ -3,12 +3,18 @@ const path = require("path")
 const cheerio = require("cheerio")
 const build = require("../../src/ulka-cli/build")
 const { createInfo } = require("../../src/utils/build-utils")
+const { rmdir } = require("../../src/utils/ulka-fs")
 
 beforeAll(async () => {
   const cwd = path.join(__dirname, "resources", "basic")
   const info = createInfo(cwd, "build")
 
   await build(info)
+})
+
+afterAll(async () => {
+  const buildDir = path.join(__dirname, "resources", "basic", "build")
+  rmdir(buildDir)
 })
 
 describe("pages - index.html", () => {

--- a/tests/e2e/resources/basic/src/pages/index.css
+++ b/tests/e2e/resources/basic/src/pages/index.css
@@ -1,3 +1,8 @@
 * {
   font-family: Arial, Helvetica, sans-serif;
+  background: url(./something.png);
+}
+
+div {
+  background: url("https://image.com/to/thepath.png");
 }

--- a/tests/e2e/resources/basic/static/my-html/index.html
+++ b/tests/e2e/resources/basic/static/my-html/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>This is my html</title>
+  </head>
+  <body>
+    hehe
+  </body>
+</html>

--- a/tests/e2e/resources/with-plugin/plugin/index.js
+++ b/tests/e2e/resources/with-plugin/plugin/index.js
@@ -7,5 +7,11 @@ module.exports = {
       name: "Roshan Acharya",
       age: 20
     }
-  }
+  },
+  beforeBuild() {},
+  afterBuild() {},
+  beforeSetup() {},
+  remarkablePlugin() {},
+  afterContentRender() {},
+  afterPageRender() {}
 }

--- a/tests/unit/utils/helpers.test.js
+++ b/tests/unit/utils/helpers.test.js
@@ -1,5 +1,6 @@
 const helpers = require("../../../src/utils/helpers")
 const path = require("path")
+const { spinner } = require("../../../src/utils/helpers")
 
 const cwd = process.cwd()
 
@@ -96,5 +97,18 @@ describe("getConfigs function", () => {
 
     expect(spy).toHaveBeenCalledWith(0)
     spy.mockRestore()
+  })
+})
+
+describe("spinner function", () => {
+  test("should be called after 1s of calling it", done => {
+    const stop = spinner()
+    const spy = jest.spyOn(process.stdout, "write")
+    setTimeout(() => {
+      stop()
+      expect(spy.mock.calls[0].length).toEqual(1)
+      spy.mockRestore()
+      done()
+    }, 100)
   })
 })

--- a/tests/unit/utils/ulka-fs.test.js
+++ b/tests/unit/utils/ulka-fs.test.js
@@ -36,6 +36,22 @@ describe("all files function", () => {
       `)
   })
 
+  test("should return the list of all files in ext array", () => {
+    const files = allFiles(allFilesTestDir, [".js", ".json"]).map(
+      replaceSepWithSlash
+    )
+    expect(files).toMatchInlineSnapshot(`
+      Array [
+        "resources/test-all-files/1-dir/1-1-dir/1-1.js",
+        "resources/test-all-files/1-dir/1-1-dir/1-1.json",
+        "resources/test-all-files/1-dir/1.js",
+        "resources/test-all-files/1-dir/1.json",
+        "resources/test-all-files/2-dir/2.js",
+        "resources/test-all-files/2-dir/2.json",
+      ]
+    `)
+  })
+
   test("should return filePath in a string of path to file is provided", () => {
     const files = allFiles(path.join(allFilesTestDir, "1-dir", "1.js")).map(
       replaceSepWithSlash
@@ -46,6 +62,10 @@ describe("all files function", () => {
           "resources/test-all-files/1-dir/1.js",
         ]
       `)
+  })
+
+  test("should throw error on fail", () => {
+    expect(() => allFiles(path.join(allFilesTestDir, "hehe"))).toThrowError()
   })
 })
 


### PR DESCRIPTION
## 0.6.6

- Assets with format \*.ignore.[ext] are ignored while copying.
- More tests and coverage
- Supported beforeSetup plugin (beforeSetup plugins run before setting map contents map and pages array).
- Removed support for getting prefix from domain in siteMetaData.
- Bug fixes
- Now it's more easy to add templating engines
- Supported use of templating files inside contents (also supports frontmatter).